### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/client-php/security/code-scanning/1](https://github.com/android-sms-gateway/client-php/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow performs basic CI tasks (checking out code, installing dependencies, and running tests), the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to repository contents and avoids granting unnecessary write permissions.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow. This is the most efficient approach since all jobs in the workflow appear to have similar permission requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI pipeline configuration to enhance repository permission settings. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->