### PR TITLE
[client] message cancelling

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -18,6 +18,7 @@ use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Client {
@@ -175,6 +176,17 @@ class Client {
             },
             $response
         );
+    }
+
+    /**
+     * Cancel a pending message by ID
+     */
+    public function CancelMessage(string $id): void {
+        if ($id === '') {
+            throw new InvalidArgumentException('Message ID must not be empty');
+        }
+        $path = '/messages/' . rawurlencode($id);
+        $this->sendRequest('DELETE', $path);
     }
 
     /**

--- a/src/Enums/ProcessState.php
+++ b/src/Enums/ProcessState.php
@@ -7,6 +7,8 @@ namespace AndroidSmsGateway\Enums;
  */
 final class ProcessState {
     public const PENDING = 'Pending';
+    public const CANCELLING = 'Cancelling';
+    public const CANCELLED = 'Cancelled';
     public const PROCESSED = 'Processed';
     public const SENT = 'Sent';
     public const DELIVERED = 'Delivered';
@@ -28,6 +30,22 @@ final class ProcessState {
      */
     public static function PENDING(): self {
         return new self(self::PENDING);
+    }
+
+    /**
+     * Cancelling - Cancellation has been requested
+     * @return self
+     */
+    public static function CANCELLING(): self {
+        return new self(self::CANCELLING);
+    }
+
+    /**
+     * Cancelled - Message has been cancelled
+     * @return self
+     */
+    public static function CANCELLED(): self {
+        return new self(self::CANCELLED);
     }
 
     /**
@@ -76,6 +94,8 @@ final class ProcessState {
 
     private const _ALL_ = [
         self::PENDING,
+        self::CANCELLING,
+        self::CANCELLED,
         self::PROCESSED,
         self::SENT,
         self::DELIVERED,

--- a/src/Enums/WebhookEvent.php
+++ b/src/Enums/WebhookEvent.php
@@ -7,6 +7,7 @@ final class WebhookEvent {
     public const SMS_SENT = 'sms:sent';
     public const SMS_DELIVERED = 'sms:delivered';
     public const SMS_FAILED = 'sms:failed';
+    public const SMS_CANCELLED = 'sms:cancelled';
     public const SYSTEM_PING = 'system:ping';
     public const APP_STARTED = 'app:started';
     public const MMS_RECEIVED = 'mms:received';
@@ -17,6 +18,7 @@ final class WebhookEvent {
         self::SMS_SENT,
         self::SMS_DELIVERED,
         self::SMS_FAILED,
+        self::SMS_CANCELLED,
         self::SYSTEM_PING,
         self::APP_STARTED,
         self::MMS_RECEIVED,
@@ -47,6 +49,10 @@ final class WebhookEvent {
 
     public static function SMS_FAILED(): self {
         return new self(self::SMS_FAILED);
+    }
+
+    public static function SMS_CANCELLED(): self {
+        return new self(self::SMS_CANCELLED);
     }
 
     public static function SYSTEM_PING(): self {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -15,6 +15,7 @@ use AndroidSmsGateway\Enums\WebhookEvent;
 use Http\Client\Curl\Client as CurlClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Mock\Client as MockClient;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -173,6 +174,39 @@ final class ClientTest extends TestCase {
             'Basic ' . base64_encode(self::MOCK_LOGIN . ':' . self::MOCK_PASSWORD),
             $req->getHeaderLine('Authorization')
         );
+    }
+
+    public function testCancelMessage(): void {
+        $responseMock = self::mockResponse('', 204);
+
+        $this->mockClient->addResponse($responseMock);
+
+        $this->client->CancelMessage('123');
+        $req = $this->mockClient->getLastRequest();
+        $this->assertEquals('DELETE', $req->getMethod());
+        $this->assertEquals('/3rdparty/v1/messages/123', $req->getUri()->getPath());
+        $this->assertEquals(
+            'Basic ' . base64_encode(self::MOCK_LOGIN . ':' . self::MOCK_PASSWORD),
+            $req->getHeaderLine('Authorization')
+        );
+    }
+
+    public function testCancelMessageEmptyId(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Message ID must not be empty');
+
+        $this->client->CancelMessage('');
+    }
+
+    public function testCancelMessageSlashInId(): void {
+        $responseMock = self::mockResponse('', 204);
+
+        $this->mockClient->addResponse($responseMock);
+
+        $this->client->CancelMessage('abc/def');
+        $req = $this->mockClient->getLastRequest();
+        $this->assertEquals('DELETE', $req->getMethod());
+        $this->assertEquals('/3rdparty/v1/messages/abc%2Fdef', $req->getUri()->getPath());
     }
 
     public function testHealthCheck(): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for cancelling messages via a new client cancel operation.
  - Introduced new message processing states for “cancelling” and “cancelled”.
  - Added support for receiving `sms:cancelled` webhook events.
- **Tests**
  - Expanded the test suite to cover message cancellation, including input validation and correct URL encoding of message IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->