### PR TITLE
[domain] add `createdAt` field to message state

### DIFF
--- a/src/Domain/MessageState.php
+++ b/src/Domain/MessageState.php
@@ -50,6 +50,12 @@ class MessageState {
     private ?DataMessage $dataMessage;
 
     /**
+     * Created at timestamp
+     * @var ?string
+     */
+    private ?string $createdAt;
+
+    /**
      * @param array<RecipientState> $recipients
      */
     public function __construct(
@@ -59,7 +65,8 @@ class MessageState {
         bool $isHashed = false,
         bool $isEncrypted = false,
         ?TextMessage $textMessage = null,
-        ?DataMessage $dataMessage = null
+        ?DataMessage $dataMessage = null,
+        ?string $createdAt = null
     ) {
         $this->id = $id;
         $this->state = $state;
@@ -68,6 +75,7 @@ class MessageState {
         $this->isEncrypted = $isEncrypted;
         $this->textMessage = $textMessage;
         $this->dataMessage = $dataMessage;
+        $this->createdAt = $createdAt;
     }
 
     /**
@@ -118,6 +126,14 @@ class MessageState {
         return $this->dataMessage;
     }
 
+    /**
+     * Get created at timestamp
+     * @return ?string
+     */
+    public function CreatedAt(): ?string {
+        return $this->createdAt;
+    }
+
     public function Decrypt(Encryptor $encryptor): self {
         if ($this->isHashed) {
             return $this;
@@ -161,7 +177,8 @@ class MessageState {
             $obj->isHashed ?? false,
             $obj->isEncrypted ?? false,
             isset($obj->textMessage) ? TextMessage::FromObject($obj->textMessage) : null,
-            isset($obj->dataMessage) ? DataMessage::FromObject($obj->dataMessage) : null
+            isset($obj->dataMessage) ? DataMessage::FromObject($obj->dataMessage) : null,
+            $obj->createdAt ?? null
         );
     }
 }

--- a/tests/Domain/MessageStateTest.php
+++ b/tests/Domain/MessageStateTest.php
@@ -41,6 +41,71 @@ final class MessageStateTest extends TestCase {
         $this->assertSame($recipients, $messageState->Recipients());
     }
 
+    public function testCanGetCreatedAt(): void {
+        $createdAt = '2024-01-02T03:04:05+02:00';
+        $messageState = new MessageState('msg_123', $this->processStateMock, [$this->recipientStateMock], false, false, null, null, $createdAt);
+        $this->assertEquals($createdAt, $messageState->CreatedAt());
+    }
+
+    public function testCreatedAtDefaultsToNull(): void {
+        $messageState = new MessageState('msg_123', $this->processStateMock, [$this->recipientStateMock]);
+        $this->assertNull($messageState->CreatedAt());
+    }
+
+    public function testCanCreateFromObjectWithCreatedAt(): void {
+        $createdAt = '2024-01-02T03:04:05+02:00';
+        $obj = (object) [
+            'id' => 'msg_123',
+            'state' => ProcessState::PENDING,
+            'createdAt' => $createdAt,
+            'recipients' => [
+                (object) [
+                    'phoneNumber' => '+1234567890',
+                    'state' => ProcessState::PENDING,
+                ],
+            ]
+        ];
+
+        $messageState = MessageState::FromObject($obj);
+
+        $this->assertEquals($createdAt, $messageState->CreatedAt());
+    }
+
+    public function testCanCreateFromObjectWithoutCreatedAt(): void {
+        $obj = (object) [
+            'id' => 'msg_123',
+            'state' => ProcessState::PENDING,
+            'recipients' => [
+                (object) [
+                    'phoneNumber' => '+1234567890',
+                    'state' => ProcessState::PENDING,
+                ],
+            ]
+        ];
+
+        $messageState = MessageState::FromObject($obj);
+
+        $this->assertNull($messageState->CreatedAt());
+    }
+
+    public function testCanCreateFromObjectWithMalformedCreatedAt(): void {
+        $obj = (object) [
+            'id' => 'msg_123',
+            'state' => ProcessState::PENDING,
+            'createdAt' => 'not-a-valid-timestamp',
+            'recipients' => [
+                (object) [
+                    'phoneNumber' => '+1234567890',
+                    'state' => ProcessState::PENDING,
+                ],
+            ]
+        ];
+
+        $messageState = MessageState::FromObject($obj);
+
+        $this->assertEquals('not-a-valid-timestamp', $messageState->CreatedAt());
+    }
+
     public function testCanCreateFromObject(): void {
         $id = 'msg_123';
         $obj = (object) [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message states now include an optional creation timestamp.
  * Creation timestamps can be read when available and are preserved as provided, including malformed values.
  * Existing messages without a timestamp continue to work with a null value.

* **Tests**
  * Added coverage for timestamp handling when provided, omitted, or read from message data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->